### PR TITLE
Update FrmMain.cs

### DIFF
--- a/ChameleonMiniGUI/FrmMain.cs
+++ b/ChameleonMiniGUI/FrmMain.cs
@@ -1795,7 +1795,7 @@ namespace ChameleonMiniGUI
 
                 // wait to make sure data is transmitted
                 Thread.Sleep(100);
-                int blockLimit = 275;
+                int blockLimit = 512;
 
                 var cts = new CancellationTokenSource();
                 var rx_data = new byte[blockLimit];


### PR DESCRIPTION
fix #139
increase download block size in order to get all text response from device when issuing "HELP",    Thanks @Loupetre